### PR TITLE
updated the help menu so it will acutaly show when needed.

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -64,7 +64,7 @@ class Game
         gym_menu
       when '7'
         store_menu
-      when '?'
+      when 'help'
         help_menu
       else
         echo(game_text(:bad_selection), :red, 0)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -66,6 +66,8 @@ class Game
         store_menu
       when 'help'
         help_menu
+      when 'exit'
+        exit
       else
         echo(game_text(:bad_selection), :red, 0)
         echo(game_text(:main_menu), :blue, 0)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -89,6 +89,7 @@ class Game
         available_options << (select_number + 1)
       end
       loop do
+        echo("You have $#{@player.wallet} on you.") 
         menu_option = ask("Select your option: ", Integer) { |q| q.in = available_options.map(&:to_i) }
         drug = drugs[menu_option - 1]
         amount = ask("How Many? ", Integer) { |q| q.above = 0 }


### PR DESCRIPTION
While on the Main_menu player you should receive help by entering a "?", but not help_menu pops up. It falls to the "else" case instead. 
Changed: 
"?" --> "help"